### PR TITLE
fix: add documentation and transform object to #24 guide

### DIFF
--- a/telegram/objects/file.py
+++ b/telegram/objects/file.py
@@ -16,7 +16,9 @@ class File(BaseObject):
 
     __slots__ = (
         'file_size', 
-        'file_path'
+        'file_path',
+        'file_size',
+        'file_path',
         )
     
     

--- a/telegram/objects/file.py
+++ b/telegram/objects/file.py
@@ -14,7 +14,10 @@ class File(BaseObject):
         file_path (str): Optional. File path. Use https://api.telegram.org/file/bot<token>/<file_path> to get the file.
     """
 
-    __slots__ = ('file_size', 'file_path')
+    __slots__ = (
+        'file_size', 
+        'file_path'
+        )
     
     
     def __init__(self, file_id, file_unique_id):
@@ -23,4 +26,4 @@ class File(BaseObject):
         self.file_size = None
         self.file_path = None
         
-        
+

--- a/telegram/objects/file.py
+++ b/telegram/objects/file.py
@@ -1,15 +1,26 @@
 from .base import BaseObject
 
 class File(BaseObject):
-    def __init__(self,
-        file_id,
-        file_unique_id,
-        file_size = None,
-        file_path = None
-        ):
+    """
+    This object represents a file ready to be downloaded.
 
+    Args:
+        file_id (str): Unique identifier for this file
+
+        file_unique_id (str): Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+        
+        file_size (int): Optional. File size, if known
+        
+        file_path (str): Optional. File path. Use https://api.telegram.org/file/bot<token>/<file_path> to get the file.
+    """
+
+    __slots__ = ('file_size', 'file_path')
+    
+    
+    def __init__(self, file_id, file_unique_id):
         self.file_id = file_id
         self.file_unique_id = file_unique_id
-        self.file_size = file_size
-        self.file_path = file_path
-      
+        self.file_size = None
+        self.file_path = None
+        
+        

--- a/telegram/objects/inputfile.py
+++ b/telegram/objects/inputfile.py
@@ -6,9 +6,25 @@ class InputFile(BaseObject):
     """
     
 class InputMedia(BaseObject):
-    """This object represents the content of a media message to be sent.
-
     """
+    This object represents the content of a media message to be sent.
+
+    Args:
+        type (str): Type of the result, must be photo
+        media (str): File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass "attach://<file_attach_name>" to upload a new one using multipart/form-data under <file_attach_name> name.
+        caption (str): Optional. Caption of the photo to be sent, 0-1024 characters after entities parsing
+        parse_mode (str): Optional. Mode for parsing entities in the photo caption. See formatting options for more details.
+        caption_entities (List[:obj:`MessageEntity`]): Optional. List of special entities that appear in the caption, which can be specified instead of parse_mode
+    """
+    
+    __slots__ = ('caption', 'parse_mode', 'caption_entities')
+    
+    def __init__(self, type, media):
+        self.type = type
+        self.media = media
+        self.caption = None
+        self.parse_mode = None
+        self.caption_entities = None
     
 class InputMediaAnimation(BaseObject):
     """Represents an animation file (GIF or H.264/MPEG-4 AVC video without sound) to be sent.

--- a/telegram/objects/inputfile.py
+++ b/telegram/objects/inputfile.py
@@ -18,9 +18,11 @@ class InputMedia(BaseObject):
     """
     
     __slots__ = (
+        'type',
+        'media',
         'caption', 
         'parse_mode', 
-        'caption_entities'
+        'caption_entities',
     )
     
     def __init__(self, type, media):
@@ -54,6 +56,8 @@ class InputMediaAnimation(BaseObject):
     """
 
     __slots__ = (
+        "type",
+        "media",
         "thumb",
         "caption",
         "parse_mode",
@@ -98,6 +102,8 @@ class InputMediaAudio(BaseObject):
     """
 
     __slots__ = (
+        "type",
+        "media",
         "thumb",
         "caption",
         "parse_mode",
@@ -138,6 +144,9 @@ class InputMediaDocument(BaseObject):
     """
 
     __slots__ = (
+        "type",
+        "media",
+        "thumb",
         "caption",
         "parse_mode",
         "caption_entities",
@@ -169,6 +178,8 @@ class InputMediaPhoto(BaseObject):
     """
 
     __slots__ = (
+        "type",
+        "media",
         "caption",
         "parse_mode",
         "caption_entities"
@@ -207,6 +218,8 @@ class InputMediaVideo(BaseObject):
     """
     
     __slots__ = (
+        "type",
+        "media",
         "thumb",
         "caption",
         "parse_mode",

--- a/telegram/objects/inputfile.py
+++ b/telegram/objects/inputfile.py
@@ -17,7 +17,11 @@ class InputMedia(BaseObject):
         caption_entities (List[:obj:`MessageEntity`]): Optional. List of special entities that appear in the caption, which can be specified instead of parse_mode
     """
     
-    __slots__ = ('caption', 'parse_mode', 'caption_entities')
+    __slots__ = (
+        'caption', 
+        'parse_mode', 
+        'caption_entities'
+    )
     
     def __init__(self, type, media):
         self.type = type

--- a/telegram/objects/location.py
+++ b/telegram/objects/location.py
@@ -8,7 +8,9 @@ class Location(BaseObject):
         longitude (float): Longitude as defined by sender
         latitude (float): Latitude as defined by sender
     """
-
+    
+    __slots__ = ("longitude","latitude")
+    
     def __init__(self, longitude, latitude):
         self.longitude = longitude
         self.latitude = latitude

--- a/telegram/objects/location.py
+++ b/telegram/objects/location.py
@@ -1,4 +1,15 @@
 from .base import BaseObject
 
 class Location(BaseObject):
-    pass 
+    """
+    This object represents a point on the map.
+
+    Args:
+        longitude (float): Longitude as defined by sender
+        latitude (float): Latitude as defined by sender
+    """
+
+    def __init__(self, longitude, latitude):
+        self.longitude = longitude
+        self.latitude = latitude
+

--- a/telegram/objects/loginurl.py
+++ b/telegram/objects/loginurl.py
@@ -1,4 +1,30 @@
 from .base import BaseObject
 
 class LoginUrl(BaseObject):
-    pass
+    """
+    This object represents a parameter of the inline keyboard button used to automatically authorize a user. Serves as a great replacement for the Telegram Login Widget when the user is coming from Telegram. All the user needs to do is tap/click a button and confirm that they want to log in:
+
+    Telegram apps support these buttons as of version 5.7.
+
+    Args:
+        url (str): An HTTP URL to be opened with user authorization data added to the query string when the button is pressed. If the user refuses to provide authorization data, the original URL without information about the user will be opened. The data added is the same as described in Receiving authorization data.
+
+        forward_text (str): Optional. New text of the button in forwarded messages.
+
+        bot_username (str): Optional. Username of a bot, which will be used for user authorization. See Setting up a bot for more details. If not specified, the current bot's username will be assumed. The url's domain must be the same as the domain linked with the bot. See Linking your domain to the bot for more details.
+
+        request_write_access (bool): Optional. Pass True to request the permission for your bot to send messages to the user.
+    """
+
+    __slots__ = (
+        'forward_text', 
+        'bot_username', 
+        'request_write_access'
+        )
+    
+    
+    def __init__(self, url):
+        self.url = url
+        self.forward_text = None
+        self.bot_username = None
+        self.request_write_access = None

--- a/telegram/objects/loginurl.py
+++ b/telegram/objects/loginurl.py
@@ -17,6 +17,7 @@ class LoginUrl(BaseObject):
     """
 
     __slots__ = (
+        'url',
         'forward_text', 
         'bot_username', 
         'request_write_access'

--- a/telegram/objects/message.py
+++ b/telegram/objects/message.py
@@ -61,6 +61,7 @@ class Message(BaseObject):
         reply_markup (:class:`telegram.InlineKeyboardMarkup`): Optional. Inline keyboard attached to the message. login_url buttons are represented as ordinary url buttons.
     """
     __slots__ = (
+        'message_id',
         'from_user',
         'date',
         'chat',
@@ -115,8 +116,6 @@ class Message(BaseObject):
         'voice_chat_participants_invited',
         'reply_markup'
     )
-
-
     
     def __init__ (self, message_id):
         self.message_id = message_id
@@ -187,7 +186,8 @@ class MessageAutoDeleteTimerChanged(BaseObject):
 
     """
 
-
+    __slots__ = ("message","message_auto_delete_time")
+    
     def __init__(self, message, message_auto_delete_time):
         self.message = message
         self.message_auto_delete_time = message_auto_delete_time
@@ -212,6 +212,9 @@ class MessageEntity(BaseObject):
     """
 
     __slots__ = (
+        'type',
+        'offset',
+        'length',
         'url', 
         'user', 
         'language'
@@ -233,7 +236,9 @@ class MessageId(BaseObject):
         message_id (int): Unique message identifier
 
     """
-
+    
+    __slots__ = ("message_id")
+    
     def __init__(self, message_id):
         self.message_id = message_id
         

--- a/telegram/objects/message.py
+++ b/telegram/objects/message.py
@@ -1,148 +1,239 @@
 from .base import BaseObject
 
 class Message(BaseObject):
-    def __init__ (self,
-        message_id,
-        from_ = None,
-        sender_chat = None,
-        date = None,
-        chat = None,
-        forward_from = None,
-        forward_from_chat = None,
-        forward_from_message_id = None,
-        forward_signature = None,
-        forward_sender_name = None,
-        forward_date = None,
-        is_automatic_forward = None,
-        reply_to_message = None,
-        via_bot = None,
-        edit_date = None,
-        has_protected_content = None,
-        media_group_id = None,
-        author_signature = None,
-        text = None,
-        entities = None,
-        animation = None,
-        audio = None,
-        document = None,
-        photo = None,
-        sticker = None,
-        video = None,
-        video_note = None,
-        voice = None,
-        caption = None,
-        caption_entities = None,
-        contact = None,
-        dice = None,
-        game = None,
-        poll = None,
-        venue = None,
-        location = None,
-        new_chat_members = None,
-        left_chat_member = None,
-        new_chat_title = None,
-        new_chat_photo = None,
-        delete_chat_photo = None,
-        group_chat_created = None,
-        supergroup_chat_created = None,
-        channel_chat_created = None,
-        message_auto_delete_timer_changed = None,
-        migrate_to_chat_id = None,
-        migrate_from_chat_id = None,
-        pinned_message = None,
-        invoice = None,
-        successful_payment = None,
-        connected_website = None,
-        passport_data = None,
-        proximity_alert_triggered = None,
-        video_chat_scheduled = None,
-        video_chat_started = None,
-        video_chat_ended = None,
-        video_chat_participants_invited = None,
-        web_app_data = None,
-        reply_markup = None,
-    ):
+    """
+    This object represents a message.
+
+    Args:
+        message_id (int): Unique message identifier inside this chat
+        from_user (:class:`telegram.User`): Optional. Sender, can be empty for messages sent to channels
+        date (:class:`datetime.datetime`): Date the message was sent in Unix time
+        chat (:class:`telegram.Chat`): Conversation the message belongs to
+        forward_from (:class:`telegram.User`): Optional. For forwarded messages, sender of the original message
+        forward_from_chat (:class:`telegram.Chat`): Optional. For messages forwarded from a channel, information about the original channel
+        forward_from_message_id (int): Optional. For messages forwarded from channels, identifier of the original message in the channel
+        forward_signature (str): Optional. For messages forwarded from channels, signature of the post author if present
+        forward_sender_name (str): Optional. Sender's name for messages forwarded from users who disallow adding a link to their account in forwarded messages
+        forward_date (:class:`datetime.datetime`): Optional. For forwarded messages, date the original message was sent in Unix time
+        reply_to_message (:class:`telegram.Message`): Optional. For replies, the original message. Note that the Message object in this field will not contain further reply_to_message fields even if it itself is a reply.
+        via_bot (:class:`telegram.User`): Optional. Bot through which the message was sent
+        edit_date (:class:`datetime.datetime`): Optional. Date the message was last edited in Unix time
+        media_group_id (str): Optional. The unique identifier of a media message group this message belongs to
+        author_signature (str): Optional. Signature of the post author for messages in channels
+        text (str): Optional. For text messages, the actual UTF-8 text of the message, 0-4096 characters.
+        entities (List[:class:`telegram.MessageEntity`]): Optional. For text messages, special entities like usernames, URLs, bot commands, etc. that appear in the text
+        caption_entities (List[:class:`telegram.MessageEntity`]): Optional. For messages with a caption, special entities like usernames, URLs, bot commands, etc. that appear in the caption
+        audio (:class:`telegram.Audio`): Optional. Message is an audio file, information about the file
+        document (:class:`telegram.Document`): Optional. Message is a general file, information about the file
+        animation (:class:`telegram.Animation`): Optional. Message is an animation, information about the animation. For backward compatibility, when this field is set, the document field will also be set
+        game (:class:`telegram.Game`): Optional. Message is a game, information about the game. More about games »
+        photo (List[:class:`telegram.PhotoSize`]): Optional. Message is a photo, available sizes of the photo
+        sticker (:class:`telegram.Sticker`): Optional. Message is a sticker, information about the sticker
+        video (:class:`telegram.Video`): Optional. Message is a video, information about the video
+        voice (:class:`telegram.Voice`): Optional. Message is a voice message, information about the file
+        video_note (:class:`telegram.VideoNote`): Optional. Message is a video note, information about the video message
+        caption (str): Optional. Caption for the animation, audio, document, photo, video or voice, 0-1024 characters
+        contact (:class:`telegram.Contact`): Optional. Message is a shared contact, information about the contact
+        location (:class:`telegram.Location`): Optional. Message is a shared location, information about the location
+        venue (:class:`telegram.Venue`): Optional. Message is a venue, information about the venue. For backward compatibility, when this field is set, the location field will also be set
+        poll (:class:`telegram.Poll`): Optional. Message is a native poll, information about the poll
+        dice (:class:`telegram.Dice`): Optional. Message is a dice with random value from 1 to 6
+        new_chat_members (List[:class:`telegram.User`]): Optional. New members that were added to the group or supergroup and information about them (the bot itself may be one of these members)
+        left_chat_member (:class:`telegram.User`): Optional. A member was removed from the group, information about them (this member may be the bot itself)
+        new_chat_title (str): Optional. A chat title was changed to this value
+        new_chat_photo (List[:class:`telegram.PhotoSize`]): Optional. A chat photo was change to this value
+        delete_chat_photo (bool): Optional. Service message: the chat photo was deleted
+        group_chat_created (bool): Optional. Service message: the group has been created
+        supergroup_chat_created (bool): Optional .Service message: the supergroup has been created. This field can't be received in a message coming through updates, because bot can't be a member of a supergroup when it is created. It can only be found in reply_to_message if someone replies to a very first message in a directly created supergroup.
+        channel_chat_created (bool): Optional. Service message: the channel has been created. This field can't be received in a message coming through updates, because bot can't be a member of a channel when it is created. It can only be found in reply_to_message if someone replies to a very first message in a channel.
+        migrate_to_chat_id (int): Optional. The group has been migrated to a supergroup with the specified identifier. This number may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it. But it is smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier.
+        migrate_from_chat_id (int): Optional. The supergroup has been migrated from a group with the specified identifier. This number may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it. But it is smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier.
+        pinned_message (:class:`telegram.Message`): Optional. Specified message was pinned. Note that the Message object in this field will not contain further reply_to_message fields even if it is itself a reply.
+        invoice (:class:`telegram.Invoice`): Optional. Message is an invoice for a payment, information about the invoice. More about payments »
+        successful_payment (:class:`telegram.SuccessfulPayment`): Optional. Message is a service message about a successful payment, information about the payment. More about payments »
+        connected_website (str): Optional. The domain name of the website on which the user has logged in. More about Telegram Login »
+        passport_data (:class:`telegram.PassportData`): Optional. Telegram Passport data
+        proximity_alert_triggered (:class:`telegram.ProximityAlertTriggered`): Optional. Service message. A user in the chat triggered another user's proximity alert while sharing Live Location.
+        voice_chat_scheduled (:class:`telegram.VoiceChatScheduled`): Optional. Service message: voice chat scheduled
+        voice_chat_started (:class:`telegram.VoiceChatStarted`): Optional. Service message: voice chat started
+        voice_chat_ended (:class:`telegram.VoiceChatEnded`): Optional. Service message: voice chat ended
+        voice_chat_participants_invited (:class:`telegram.VoiceChatParticipantsInvited`): Optional. Service message: new participants invited to a voice chat
+        reply_markup (:class:`telegram.InlineKeyboardMarkup`): Optional. Inline keyboard attached to the message. login_url buttons are represented as ordinary url buttons.
+    """
+    __slots__ = (
+        'from_user',
+        'date',
+        'chat',
+        'forward_from',
+        'forward_from_chat',
+        'forward_from_message_id',
+        'forward_signature',
+        'forward_sender_name',
+        'forward_date',
+        'reply_to_message',
+        'via_bot',
+        'edit_date',
+        'media_group_id',
+        'author_signature',
+        'text',
+        'entities',
+        'caption_entities',
+        'audio',
+        'document',
+        'animation',
+        'game',
+        'photo',
+        'sticker',
+        'video',
+        'voice',
+        'video_note',
+        'caption',
+        'contact',
+        'location',
+        'venue',
+        'poll',
+        'dice',
+        'new_chat_members',
+        'left_chat_member',
+        'new_chat_title',
+        'new_chat_photo',
+        'delete_chat_photo',
+        'group_chat_created',
+        'supergroup_chat_created',
+        'channel_chat_created',
+        'migrate_to_chat_id',
+        'migrate_from_chat_id',
+        'pinned_message',
+        'invoice',
+        'successful_payment',
+        'connected_website',
+        'passport_data',
+        'proximity_alert_triggered',
+        'voice_chat_scheduled',
+        'voice_chat_started',
+        'voice_chat_ended',
+        'voice_chat_participants_invited',
+        'reply_markup'
+    )
+
+
+    
+    def __init__ (self, message_id):
         self.message_id = message_id
-        self.from_ = from_
-        self.sender_chat = sender_chat
-        self.date = date
-        self.chat = chat
-        self.forward_from = forward_from
-        self.forward_from_chat = forward_from_chat
-        self.forward_from_message_id = forward_from_message_id
-        self.forward_signature = forward_signature
-        self.forward_sender_name = forward_sender_name
-        self.forward_date = forward_date
-        self.is_automatic_forward = is_automatic_forward
-        self.reply_to_message = reply_to_message
-        self.via_bot = via_bot
-        self.edit_date = edit_date
-        self.has_protected_content = has_protected_content
-        self.media_group_id = media_group_id
-        self.author_signature = author_signature
-        self.text = text
-        self.entities = entities
-        self.animation = animation
-        self.audio = audio
-        self.document = document
-        self.photo = photo
-        self.sticker = sticker
-        self.video = video
-        self.video_note = video_note
-        self.voice = voice
-        self.caption = caption
-        self.caption_entities = caption_entities
-        self.contact = contact
-        self.dice = dice
-        self.game = game
-        self.poll = poll
-        self.venue = venue
-        self.location = location
-        self.new_chat_members = new_chat_members
-        self.left_chat_member = left_chat_member
-        self.new_chat_title = new_chat_title
-        self.new_chat_photo = new_chat_photo
-        self.delete_chat_photo = delete_chat_photo
-        self.group_chat_created = group_chat_created
-        self.supergroup_chat_created = supergroup_chat_created
-        self.channel_chat_created = channel_chat_created
-        self.message_auto_delete_timer_changed = message_auto_delete_timer_changed
-        self.migrate_to_chat_id = migrate_to_chat_id
-        self.migrate_from_chat_id = migrate_from_chat_id
-        self.pinned_message = pinned_message
-        self.invoice = invoice
-        self.successful_payment = successful_payment
-        self.connected_website = connected_website
-        self.passport_data = passport_data
-        self.proximity_alert_triggered = proximity_alert_triggered
-        self.video_chat_scheduled = video_chat_scheduled
-        self.video_chat_started = video_chat_started
-        self.video_chat_ended = video_chat_ended
-        self.video_chat_participants_invited = video_chat_participants_invited
-        self.web_app_data = web_app_data
-        self.reply_markup = reply_markup
+        self.from_user = None
+        self.date = None
+        self.chat = None
+        self.forward_from = None
+        self.forward_from_chat = None
+        self.forward_from_message_id = None
+        self.forward_signature = None
+        self.forward_sender_name = None
+        self.forward_date = None
+        self.reply_to_message = None
+        self.via_bot = None
+        self.edit_date = None
+        self.media_group_id = None
+        self.author_signature = None
+        self.text = None
+        self.entities = None
+        self.caption_entities = None
+        self.audio = None
+        self.document = None
+        self.animation = None
+        self.game = None
+        self.photo = None
+        self.sticker = None
+        self.video = None
+        self.voice = None
+        self.video_note = None
+        self.caption = None
+        self.contact = None
+        self.location = None
+        self.venue = None
+        self.poll = None
+        self.dice = None
+        self.new_chat_members = None
+        self.left_chat_member = None
+        self.new_chat_title = None
+        self.new_chat_photo = None
+        self.delete_chat_photo = None
+        self.group_chat_created = None
+        self.supergroup_chat_created = None
+        self.channel_chat_created = None
+        self.migrate_to_chat_id = None
+        self.migrate_from_chat_id = None
+        self.pinned_message = None
+        self.invoice = None
+        self.successful_payment = None
+        self.connected_website = None
+        self.passport_data = None
+        self.proximity_alert_triggered = None
+        self.voice_chat_scheduled = None
+        self.voice_chat_started = None
+        self.voice_chat_ended = None
+        self.voice_chat_participants_invited = None
+        self.reply_markup = None
 
 class MessageAutoDeleteTimerChanged(BaseObject):
-    pass 
+    """This object represents a service message about a change in auto-delete timer settings.
+
+    Args:
+        message (:class:`telegram.Message`): The message with the change.
+        message_auto_delete_time (:class:`telegram.MessageAutoDeleteTimerChanged`): New auto-delete time for messages in the chat.
+
+    Attributes:
+        message (:class:`telegram.Message`): The message with the change.
+        message_auto_delete_time (:class:`telegram.MessageAutoDeleteTimerChanged`): New auto-delete time for messages in the chat.
+
+    """
+
+
+    def __init__(self, message, message_auto_delete_time):
+        self.message = message
+        self.message_auto_delete_time = message_auto_delete_time
+
 
 class MessageEntity(BaseObject):
-    def __init__ (self,
-        type,
-        offset,
-        length,
-        url = None,
-        language = None,
-        custom_emoji_id = None,
-    ):
+    """
+    This object represents one special entity in a text message. For example, hashtags, usernames, URLs, etc.
+
+    Args:
+        type (str): Type of the entity. Can be mention (@username), hashtag, cashtag, bot_command, 
+        url, email, phone_number, bold (bold text), italic (italic text), code (monowidth string), 
+        pre (monowidth block), text_link (for clickable text URLs), text_mention (for users without usernames)
+
+        offset (int): Offset in UTF-16 code units to the start of the entity
+        length (int): Length of the entity in UTF-16 code units
+        url (str): Optional. For “text_link” only, url that will be opened after user taps on the text
+        user (:class:`telegram.User`): Optional. For “text_mention” only, the mentioned user
+        language (str): Optional. For “pre” only, the programming language of the entity text
+        custom_emoji_id (str): Optional. For “custom_emoji” only, the custom emoji id
+
+    """
+
+    __slots__ = (
+        'url', 
+        'user', 
+        'language'
+        )
+
+    def __init__(self, type, offset, length):
         self.type = type
         self.offset = offset
         self.length = length
-        self.url = url
-        self.language = language
-        self.custom_emoji_id = custom_emoji_id
+        self.url = None
+        self.user = None
+        self.language = None
 
 class MessageId(BaseObject):
-    def __init__ (self,
-        message_id
-    ):
+    """
+    This object represents a unique message identifier.
+
+    Args:
+        message_id (int): Unique message identifier
+
+    """
+
+    def __init__(self, message_id):
         self.message_id = message_id
+        

--- a/telegram/objects/photosize.py
+++ b/telegram/objects/photosize.py
@@ -25,3 +25,12 @@ class PhotoSize(BaseObject):
         self.width = width
         self.height = height
         self.file_size = None
+
+    @classmethod
+    def de_json(cls, data, bot):
+        if not data:
+            return None
+
+        data = super(PhotoSize, cls).de_json(data, bot)
+
+        return cls(**data)

--- a/telegram/objects/photosize.py
+++ b/telegram/objects/photosize.py
@@ -16,6 +16,10 @@ class PhotoSize(BaseObject):
     """
 
     __slots__ = (
+        "file_id",
+        "file_unique_id",
+        "width",
+        "height",
         "file_size",
     )
 

--- a/telegram/objects/photosize.py
+++ b/telegram/objects/photosize.py
@@ -26,4 +26,4 @@ class PhotoSize(BaseObject):
         self.height = height
         self.file_size = None
 
-
+ 

--- a/telegram/objects/photosize.py
+++ b/telegram/objects/photosize.py
@@ -26,11 +26,4 @@ class PhotoSize(BaseObject):
         self.height = height
         self.file_size = None
 
-    @classmethod
-    def de_json(cls, data, bot):
-        if not data:
-            return None
 
-        data = super(PhotoSize, cls).de_json(data, bot)
-
-        return cls(**data)

--- a/telegram/objects/proximityalerttriggered.py
+++ b/telegram/objects/proximityalerttriggered.py
@@ -1,4 +1,17 @@
 from .base import BaseObject
 
 class ProximityAlertTriggered(BaseObject):
-    pass 
+    """
+    This object represents the content of a service message, sent whenever a user in the chat triggers a proximity alert set by another user.
+
+    Args:
+        traveler (telegram.objects.user.User): User that triggered the alert
+        watcher (telegram.objects.user.User): User that set the alert
+        distance (int): The distance between the users
+    """
+    
+    
+    def __init__(self, traveler, watcher, distance):
+        self.traveler = traveler
+        self.watcher = watcher
+        self.distance = distance

--- a/telegram/objects/proximityalerttriggered.py
+++ b/telegram/objects/proximityalerttriggered.py
@@ -10,6 +10,7 @@ class ProximityAlertTriggered(BaseObject):
         distance (int): The distance between the users
     """
     
+    __slots__ = ("traveler","watcher","distance")
     
     def __init__(self, traveler, watcher, distance):
         self.traveler = traveler

--- a/telegram/objects/replykeyboard.py
+++ b/telegram/objects/replykeyboard.py
@@ -12,6 +12,7 @@ class ReplyKeyboardMarkup(BaseObject):
     """
     
     __slots__ = (
+        'keyboard',
         'resize_keyboard', 
         'one_time_keyboard', 
         'selective'
@@ -34,7 +35,8 @@ class ReplyKeyboardRemove(BaseObject):
     """
     
     __slots__ = (
-        'selective'
+        'remove_keyboard',
+        'selective',
         )
     
     

--- a/telegram/objects/replykeyboard.py
+++ b/telegram/objects/replykeyboard.py
@@ -1,7 +1,44 @@
 from .base import BaseObject
 
 class ReplyKeyboardMarkup(BaseObject):
-    pass 
+    """
+    This object represents a custom keyboard with reply options (see Introduction to bots for details and examples).
+    
+    Args:
+        keyboard (list): Array of button rows, each represented by an Array of KeyboardButton objects
+        resize_keyboard (bool): Optional. Requests clients to resize the keyboard vertically for optimal fit (e.g., make the keyboard smaller if there are just two rows of buttons). Defaults to False, in which case the custom keyboard is always of the same height as the app's standard keyboard.
+        one_time_keyboard (bool): Optional. Requests clients to hide the keyboard as soon as it's been used. The keyboard will still be available, but clients will automatically display the usual letter-keyboard in the chat – the user can press a special button in the input field to see the custom keyboard again. Defaults to False.
+        selective (bool): Optional. Use this parameter if you want to show the keyboard to specific users only. Targets: 1) users that are @mentioned in the text of the Message object; 2) if the bot's message is a reply (has reply_to_message_id), sender of the original message. Example: A user requests to change the bot‘s language, bot replies to the request with a keyboard to select the new language. Other users in the group don’t see the keyboard.
+    """
+    
+    __slots__ = (
+        'resize_keyboard', 
+        'one_time_keyboard', 
+        'selective'
+        )
+    
+    
+    def __init__(self, keyboard):
+        self.keyboard = keyboard
+        self.resize_keyboard = None
+        self.one_time_keyboard = None
+        self.selective = None
 
 class ReplyKeyboardRemove(BaseObject):
-    pass
+    """
+    Upon receiving a message with this object, Telegram clients will remove the current custom keyboard and display the default letter-keyboard. By default, custom keyboards are displayed until a new keyboard is sent by a bot. An exception is made for one-time keyboards that are hidden immediately after the user presses a button (see ReplyKeyboardMarkup).
+    
+    Args:
+        remove_keyboard (bool): Requests clients to remove the custom keyboard (user will not be able to summon this keyboard; if you want to hide the keyboard from sight but keep it accessible, use one_time_keyboard in ReplyKeyboardMarkup)
+        selective (bool): Optional. Use this parameter if you want to remove the keyboard for specific users only. Targets: 1) users that are @mentioned in the text of the Message object; 2) if the bot's message is a reply (has reply_to_message_id), sender of the original message. Example: A user votes in a poll, bot returns confirmation message in reply to the vote and removes the keyboard for that user, while still showing the keyboard with poll options to users who haven't voted yet.
+    """
+    
+    __slots__ = (
+        'selective'
+        )
+    
+    
+    def __init__(self, remove_keyboard):
+        self.remove_keyboard = remove_keyboard
+        self.selective = None
+

--- a/telegram/objects/responseparameters.py
+++ b/telegram/objects/responseparameters.py
@@ -1,4 +1,23 @@
 from .base import BaseObject
 
 class ResponseParameters(BaseObject):
-    pass 
+    """
+    Contains information about why a request was unsuccessful.
+
+    Args:
+        migrate_to_chat_id (int): Optional. The group has been migrated to a supergroup with the specified identifier. 
+        This number may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it. 
+        But it is smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier.
+        
+        retry_after (int): Optional. In case of exceeding flood control, the number of seconds left to wait before the request can be repeated
+    """
+
+    __slots__ = (
+        'migrate_to_chat_id', 
+        'retry_after'
+        )
+    
+    
+    def __init__(self):
+        self.migrate_to_chat_id = None
+        self.retry_after = None

--- a/telegram/objects/update.py
+++ b/telegram/objects/update.py
@@ -1,35 +1,75 @@
 from .base import BaseObject
 
 class Update (BaseObject):
-    def __init__ (self,
-        update_id,
-        message = None,
-        edited_message = None,
-        channel_post = None,
-        edited_channel_post = None,
-        inline_query = None,
-        chosen_inline_result = None,
-        callback_query = None,
-        shipping_query = None,
-        pre_checkout_query = None,
-        poll = None,
-        poll_answer = None,
-        my_chat_member = None,
-        chat_member = None,
-        chat_join_request = None,
-    ):
+    """
+    This object represents an incoming update.
+    Only one of the optional parameters can be present in any given update.
+
+    Args:
+        update_id (int): The update's unique identifier. Update identifiers start from a certain positive number and increase sequentially. This ID becomes especially handy if you're using Webhooks, since it allows you to ignore repeated updates or to restore the correct update sequence, should they get out of order. If there are no new updates for at least a week, then identifier of the next update will be chosen randomly instead of sequentially.
+
+        message (Optional[telegram.objects.message.Message]): Optional. New incoming message of any kind — text, photo, sticker, etc.
+
+        edited_message (Optional[telegram.objects.message.Message]): Optional. New version of a message that is known to the bot and was edited
+
+        channel_post (Optional[telegram.objects.message.Message]): Optional. New incoming channel post of any kind — text, photo, sticker, etc.
+
+        edited_channel_post (Optional[telegram.objects.message.Message]): Optional. New version of a channel post that is known to the bot and was edited
+
+        inline_query (Optional[telegram.objects.inline_query.InlineQuery]): Optional. New incoming inline query
+
+        chosen_inline_result (Optional[telegram.objects.inline_query.ChosenInlineResult]): Optional. The result of an inline query that was chosen by a user and 
+        sent to their chat partner. Please see our documentation on the feedback collecting for details on how to enable these updates for your bot.
+
+        callback_query (Optional[telegram.objects.callback_query.CallbackQuery]): Optional. New incoming callback query
+
+        shipping_query (Optional[telegram.objects.shipping_query.ShippingQuery]): Optional. New incoming shipping query. Only for invoices with flexible price
+
+        pre_checkout_query (Optional[telegram.objects.pre_checkout_query.PreCheckoutQuery]): Optional. New incoming pre-checkout query. Contains full information about checkout
+
+        poll (Optional[telegram.objects.poll.Poll]): Optional. New poll state. Bots receive only updates about stopped polls and polls, which are sent by the bot
+
+        poll_answer (Optional[telegram.objects.poll.PollAnswer]): Optional. A user changed their answer in a non-anonymous poll. Bots receive new votes only in polls that were sent by the bot itself.
+
+        my_chat_member (Optional[telegram.objects.chat_member_updated.ChatMemberUpdated]): Optional. A user changed their answer in a non-anonymous poll. Bots receive new votes only in polls that were sent by the bot itself.
+
+        chat_member (Optional[telegram.objects.chat_member_updated.ChatMemberUpdated]): Optional. A user changed their answer in a non-anonymous poll. Bots receive new votes only in polls that were sent by the bot itself.
+
+        chat_join_request (Optional[telegram.objects.chat_join_request.ChatJoinRequest]): Optional. A user changed their answer in a non-anonymous poll. Bots receive new votes only in polls that were sent by the bot itself.
+    """
+
+    __slots__ = (
+        'message', 
+        'edited_message', 
+        'channel_post', 
+        'edited_channel_post', 
+        'inline_query', 
+        'chosen_inline_result', 
+        'callback_query', 
+        'shipping_query', 
+        'pre_checkout_query', 
+        'poll', 
+        'poll_answer', 
+        'my_chat_member', 
+        'chat_member', 
+        'chat_join_request'
+        )
+    
+    
+    def __init__(self, update_id):
         self.update_id = update_id
-        self.message = message
-        self.edited_message = edited_message
-        self.channel_post = channel_post
-        self.edited_channel_post = edited_channel_post
-        self.inline_query = inline_query
-        self.chosen_inline_result = chosen_inline_result
-        self.callback_query = callback_query
-        self.shipping_query = shipping_query
-        self.pre_checkout_query = pre_checkout_query
-        self.poll = poll
-        self.poll_answer = poll_answer
-        self.my_chat_member = my_chat_member
-        self.chat_member = chat_member
-        self.chat_join_request = chat_join_request
+        self.message = None
+        self.edited_message = None
+        self.channel_post = None
+        self.edited_channel_post = None
+        self.inline_query = None
+        self.chosen_inline_result = None
+        self.callback_query = None
+        self.shipping_query = None
+        self.pre_checkout_query = None
+        self.poll = None
+        self.poll_answer = None
+        self.my_chat_member = None
+        self.chat_member = None
+        self.chat_join_request = None
+

--- a/telegram/objects/update.py
+++ b/telegram/objects/update.py
@@ -39,6 +39,7 @@ class Update (BaseObject):
     """
 
     __slots__ = (
+        'update_id',
         'message', 
         'edited_message', 
         'channel_post', 

--- a/telegram/objects/user.py
+++ b/telegram/objects/user.py
@@ -51,80 +51,13 @@ class UserProfilePhotos(BaseObject):
         photos (List[List[PhotoSize]]): Requested profile pictures (in up to 4 sizes each)
     """
 
-    __slots__ = ('total_count', 'photos')
+    __slots__ = (
+        'total_count', 
+        'photos'
+        )
 
     def __init__(self, total_count, photos):
         self.total_count = total_count
         self.photos = photos
 
-    @classmethod
-    def de_json(cls, data, bot):
-        if not data:
-            return None
-
-        data = super(UserProfilePhotos, cls).de_json(data, bot)
-
-        data['photos'] = [[PhotoSize.de_json(photo, bot) for photo in photo_list] for photo_list in data['photos']]
-
-        return cls(**data)
-
-    def to_dict(self):
-        data = super(UserProfilePhotos, self).to_dict()
-
-        data['photos'] = [[photo.to_dict() for photo in photo_list] for photo_list in self.photos]
-
-        return data
-
-    def __reduce__(self):
-        return self.__class__, (self.total_count, self.photos)
-
-    def __eq__(self, other):
-        return (self.total_count == other.total_count and
-                self.photos == other.photos)
-
-    def __hash__(self):
-        return hash((self.total_count, self.photos))
-
-    def __str__(self):
-        return 'UserProfilePhotos(total_count={self.total_count!r}, photos={self.photos!r})'.format(self=self)
-
-    def __repr__(self):
-        return '<{self.__class__.__name__} total_count={self.total_count!r}, photos={self.photos!r}>'.format(self=self)
-
-    def get_file(self, file_id):
-        """
-        Shortcut for::
-
-            bot.get_file(file_id)
-
-        Args:
-            file_id (:obj:`str`): Unique identifier for the target file
-
-        Returns:
-            :class:`telegram.File`: On success, a file object is returned.
-
-        Raises:
-            :class:`telegram.TelegramError`
-
-        """
-        return self.bot.get_file(file_id)
-
-    def download(self, file_path, filename=None, **kwargs):
-        """
-        Shortcut for::
-
-            bot.download_file(file_path, filename, **kwargs)
-
-        Args:
-            file_path (:obj:`str`): File identifier to get info about
-            filename (:obj:`str`, optional): The name of the file. If not set, the file_id will be used.
-            **kwargs (:obj:`dict`): Arbitrary keyword arguments.
-
-        Returns:
-            :obj:`str`: The file path of the downloaded file.
-
-        Raises:
-            :class:`telegram.TelegramError`
-
-        """
-        return self.bot.download_file(file_path, filename, **kwargs)
+   

--- a/telegram/objects/user.py
+++ b/telegram/objects/user.py
@@ -18,6 +18,9 @@ class User(BaseObject):
         """
     
     __slots__ = (
+            'id',
+            'is_bot',
+            'first_name',
             'last_name', 
             'username', 
             'language_code', 

--- a/telegram/objects/user.py
+++ b/telegram/objects/user.py
@@ -60,4 +60,3 @@ class UserProfilePhotos(BaseObject):
         self.total_count = total_count
         self.photos = photos
 
-   

--- a/telegram/objects/user.py
+++ b/telegram/objects/user.py
@@ -1,34 +1,130 @@
+from telegram.objects.photosize import PhotoSize
 from .base import BaseObject
 
 class User(BaseObject):
-    def __init__ (self,
-        id,
-        is_bot,
-        first_name,
-        last_name = None,
-        username = None,
-        language_code = None,
-        is_premium = None,
-        added_to_attachment_menu = None,
-        can_join_groups = None,
-        can_read_all_group_messages = None,
-        supports_inline_queries = None
-    ):
-        self.id = id
-        self.is_bot = is_bot
-        self.first_name = first_name
-        self.username = username
-        self.language_code = language_code
-        self.is_premium = is_premium
-        self.added_to_attachment_menu = added_to_attachment_menu
-        self.can_join_groups = can_join_groups
-        self.can_read_all_group_messages = can_read_all_group_messages
-        self.supports_inline_queries = supports_inline_queries
+    """
+    This object represents a Telegram user or bot.
+        
+        Args:
+            id (int): Unique identifier for this user or bot
+            is_bot (bool): True, if this user is a bot
+            first_name (str): User's or bot's first name
+            last_name (Optional[str]): Optional. User's or bot's last name
+            username (Optional[str]): Optional. User's or bot's username
+            language_code (Optional[str]): Optional. IETF language tag of the user's language
+            can_join_groups (Optional[bool]): Optional. True, if the bot can be invited to groups. Returned only in getMe.
+            can_read_all_group_messages (Optional[bool]): Optional. True, if privacy mode is disabled for the bot. Returned only in getMe.
+            supports_inline_queries (Optional[bool]): Optional. True, if the bot supports inline queries. Returned only in getMe.
+        """
+    
+    __slots__ = (
+            'last_name', 
+            'username', 
+            'language_code', 
+            'can_join_groups', 
+            'can_read_all_group_messages', 
+            'supports_inline_queries'
+            )
+        
+        
+    def __init__(self, id, is_bot, first_name):
+            self.id = id
+            self.is_bot = is_bot
+            self.first_name = first_name
+            self.last_name = None
+            self.username = None
+            self.language_code = None
+            self.can_join_groups = None
+            self.can_read_all_group_messages = None
+            self.supports_inline_queries = None
+
+         
+
+
 
 class UserProfilePhotos(BaseObject):
-    def __init__ (self,
-        total_count,
-        photos,
-    ):
+    """
+    This object represent a user's profile pictures.
+
+    Args:
+        total_count (int): Total number of profile pictures the target user has
+        photos (List[List[PhotoSize]]): Requested profile pictures (in up to 4 sizes each)
+    """
+
+    __slots__ = ('total_count', 'photos')
+
+    def __init__(self, total_count, photos):
         self.total_count = total_count
         self.photos = photos
+
+    @classmethod
+    def de_json(cls, data, bot):
+        if not data:
+            return None
+
+        data = super(UserProfilePhotos, cls).de_json(data, bot)
+
+        data['photos'] = [[PhotoSize.de_json(photo, bot) for photo in photo_list] for photo_list in data['photos']]
+
+        return cls(**data)
+
+    def to_dict(self):
+        data = super(UserProfilePhotos, self).to_dict()
+
+        data['photos'] = [[photo.to_dict() for photo in photo_list] for photo_list in self.photos]
+
+        return data
+
+    def __reduce__(self):
+        return self.__class__, (self.total_count, self.photos)
+
+    def __eq__(self, other):
+        return (self.total_count == other.total_count and
+                self.photos == other.photos)
+
+    def __hash__(self):
+        return hash((self.total_count, self.photos))
+
+    def __str__(self):
+        return 'UserProfilePhotos(total_count={self.total_count!r}, photos={self.photos!r})'.format(self=self)
+
+    def __repr__(self):
+        return '<{self.__class__.__name__} total_count={self.total_count!r}, photos={self.photos!r}>'.format(self=self)
+
+    def get_file(self, file_id):
+        """
+        Shortcut for::
+
+            bot.get_file(file_id)
+
+        Args:
+            file_id (:obj:`str`): Unique identifier for the target file
+
+        Returns:
+            :class:`telegram.File`: On success, a file object is returned.
+
+        Raises:
+            :class:`telegram.TelegramError`
+
+        """
+        return self.bot.get_file(file_id)
+
+    def download(self, file_path, filename=None, **kwargs):
+        """
+        Shortcut for::
+
+            bot.download_file(file_path, filename, **kwargs)
+
+        Args:
+            file_path (:obj:`str`): File identifier to get info about
+            filename (:obj:`str`, optional): The name of the file. If not set, the file_id will be used.
+            **kwargs (:obj:`dict`): Arbitrary keyword arguments.
+
+        Returns:
+            :obj:`str`: The file path of the downloaded file.
+
+        Raises:
+            :class:`telegram.TelegramError`
+
+        """
+        return self.bot.download_file(file_path, filename, **kwargs)

--- a/telegram/objects/venue.py
+++ b/telegram/objects/venue.py
@@ -1,20 +1,44 @@
+from telegram.objects.location import Location
 from .base import BaseObject
 
 class Venue(BaseObject):
-    def __init__(self,
-        location,
-        title,
-        address,
-        foursquare_id = None,
-        foursquare_type = None,
-        google_place_id = None,
-        google_place_type = None,
-        ):
+    """
+    This object represents a venue.
 
+    Args:
+        location (Location): Venue location
+
+        title (str): Name of the venue
+
+        address (str): Address of the venue
+
+        foursquare_id (Optional[str]): Optional. Foursquare identifier of the venue
+
+        foursquare_type (Optional[str]): Optional. Foursquare type of the venue. 
+        (For example, "arts_entertainment/default", "arts_entertainment/aquarium" or "food/icecream".)
+
+        google_place_id (Optional[str]): Optional. Google Places identifier of the venue
+        
+        google_place_type (Optional[str]): Optional. Google Places type of the venue. (See supported types.)
+    """
+
+    __slots__ = (
+        'location', 
+        'title', 
+        'address', 
+        'foursquare_id', 
+        'foursquare_type', 
+        'google_place_id', 
+        'google_place_type'
+        )
+    
+    
+    def __init__(self, location, title, address):
         self.location = location
         self.title = title
         self.address = address
-        self.foursquare_id = foursquare_id
-        self.foursquare_type = foursquare_type
-        self.google_place_id = google_place_id
-        self.google_place_type = google_place_type
+        self.foursquare_id = None
+        self.foursquare_type = None
+        self.google_place_id = None
+        self.google_place_type = None
+

--- a/telegram/objects/video.py
+++ b/telegram/objects/video.py
@@ -16,6 +16,11 @@ class Video(BaseObject):
     """
 
     __slots__ = (
+        'file_id",
+        'file_unique_id',
+        'width',
+        'height',
+        'duration',
         'thumb', 
         'mime_type', 
         'file_size'
@@ -41,9 +46,10 @@ class VideoChatEnded(BaseObject):
             duration (int): Video duration in seconds
     """
     
-        
+    __slots__ = ("duration")
+    
     def __init__(self, duration):
-            self.duration = duration
+        self.duration = duration
     
 class VideoChatParticipantsInvited(BaseObject):
     """
@@ -53,6 +59,7 @@ class VideoChatParticipantsInvited(BaseObject):
         users (list[:class:`telegram.objects.user.User`]): Optional. New members that were invited to the video chat
     """
     
+    __slots__ = ("users")
     
     def __init__(self, users):
         self.users = users
@@ -65,10 +72,11 @@ class VideoChatScheduled(BaseObject):
         Args:
             start_date (:class:`telegram.objects.base.UnixTime`): Point in time (Unix timestamp) when the video chat is supposed to be started by a chat administrator
     """
-        
-        
+    
+    __slots__ = ("start_date")
+    
     def __init__(self, start_date):
-            self.start_date = start_date
+        self.start_date = start_date
 
     
 class VideoChatStarted(BaseObject):
@@ -92,6 +100,10 @@ class VideoNote(BaseObject):
     """
 
     __slots__ = (
+        'file_id',
+        'file_unique_id',
+        'length',
+        'duration',
         'thumb', 
         'file_size'
         )

--- a/telegram/objects/video.py
+++ b/telegram/objects/video.py
@@ -1,40 +1,74 @@
 from .base import BaseObject
 
 class Video(BaseObject):
-    def __init__(self,
-        file_id,
-        file_unique_id,
-        width,
-        height,
-        duration,
-        thumb = None,
-        file_name = None,
-        mime_type = None,
-        file_size = None
-        ):
+    """
+    This object represents a video file.
 
+    Args:
+        file_id (str): Unique identifier for this file
+        file_unique_id (str): Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+        width (int): Video width as defined by sender
+        height (int): Video height as defined by sender
+        duration (int): Duration of the video in seconds as defined by sender
+        thumb (:class:`telegram.objects.photo_size.PhotoSize`): Optional. Video thumbnail
+        mime_type (str): Optional. Mime type of a file as defined by sender
+        file_size (int): Optional. File size
+    """
+
+    __slots__ = (
+        'thumb', 
+        'mime_type', 
+        'file_size'
+        )
+
+    
+    def __init__(self, file_id, width, height, duration, file_unique_id):
         self.file_id = file_id
         self.file_unique_id = file_unique_id
         self.width = width
         self.height = height
         self.duration = duration
-        self.thumb = thumb
-        self.file_name = file_name
-        self.mime_type = mime_type
-        self.file_size = file_size
+        self.thumb = None
+        self.mime_type = None
+        self.file_size = None
+  
     
 class VideoChatEnded(BaseObject):
+    """
+    This object represents a service message about a video chat ended in the chat.
+    
+        Args:
+            duration (int): Video duration in seconds
+    """
+    
+        
     def __init__(self, duration):
-        self.duration = duration
+            self.duration = duration
     
 class VideoChatParticipantsInvited(BaseObject):
+    """
+    This object represents a service message about new members invited to a video chat.
+
+    Args:
+        users (list[:class:`telegram.objects.user.User`]): Optional. New members that were invited to the video chat
+    """
+    
+    
     def __init__(self, users):
         self.users = users
 
     
 class VideoChatScheduled(BaseObject):
+    """
+    This object represents a service message about a video chat scheduled in the chat.
+    
+        Args:
+            start_date (:class:`telegram.objects.base.UnixTime`): Point in time (Unix timestamp) when the video chat is supposed to be started by a chat administrator
+    """
+        
+        
     def __init__(self, start_date):
-        self.start_date = start_date
+            self.start_date = start_date
 
     
 class VideoChatStarted(BaseObject):
@@ -45,18 +79,29 @@ class VideoChatStarted(BaseObject):
 
     
 class VideoNote(BaseObject):
-    def __init__(self,
-        file_id,
-        file_unique_id,
-        length,
-        duration,
-        thumb = None,
-        file_size = None
-        ):
+    """
+    This object represents a video message (available in Telegram apps as of v.4.0).
 
+    Args:
+        file_id (str): Unique identifier for this file
+        file_unique_id (str): Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+        length (int): Video width and height (diameter of the video message) as defined by sender
+        duration (int): Duration of the video in seconds as defined by sender
+        thumb (:class:`telegram.objects.photo_size.PhotoSize`): Optional. Video thumbnail
+        file_size (int): Optional. File size
+    """
+
+    __slots__ = (
+        'thumb', 
+        'file_size'
+        )
+
+    
+    def __init__(self, file_id, length, duration, file_unique_id):
         self.file_id = file_id
         self.file_unique_id = file_unique_id
         self.length = length
         self.duration = duration
-        self.thumb = thumb
-        self.file_size = file_size
+        self.thumb = None
+        self.file_size = None
+  

--- a/telegram/objects/voice.py
+++ b/telegram/objects/voice.py
@@ -1,15 +1,27 @@
 from .base import BaseObject
 
 class Voice(BaseObject):
-    def __init__ (self,
-        file_id,
-        file_unique_id,
-        duration,
-        mime_type = None,
-        file_size = None,
-    ):
+    """
+    This object represents a voice note.
+
+    Args:
+        file_id (str): Unique identifier for this file
+        file_unique_id (str): Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+        duration (int): Duration of the audio in seconds as defined by sender
+        mime_type (str): Optional. MIME type of the file as defined by sender
+        file_size (int): Optional. File size
+    """
+
+    __slots__ = (
+        'mime_type',
+        'file_size'
+        )
+
+    
+    def __init__(self, file_id, file_unique_id, duration):
         self.file_id = file_id
         self.file_unique_id = file_unique_id
         self.duration = duration
-        self.mime_type = mime_type
-        self.file_size = file_size
+        self.mime_type = None
+        self.file_size = None
+ 

--- a/telegram/objects/voice.py
+++ b/telegram/objects/voice.py
@@ -13,6 +13,9 @@ class Voice(BaseObject):
     """
 
     __slots__ = (
+        'file_id',
+        'file_unique_id',
+        'duration',
         'mime_type',
         'file_size'
         )


### PR DESCRIPTION
This PR adds documentation and properties to the following objects based on #24 guide

- [x] File
- [x] InputMedia
- [x] Update
- [x] User
- [x] UserProfilePhotos    
- [x] LoginUrl
- [x] Location
- [x]  ProximityAlertTriggered
- [x] ReplyKeyboardMarkup
- [x] ReplyKeyboardRemove
- [x] ResponseParameters
- [x] Venue
- [x] Video
- [x] VideoChatEnded
- [x] VideoChatParticipantsInvited
- [x] VideoChatScheduled
- [x] VideoNote
- [x] Voice          