### PR TITLE
Docs: GitHub pages deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: ci 
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - run: pip install mkdocs-material 
+      - run: mkdocs gh-deploy --force


### PR DESCRIPTION
This pr adds ability for when a new commit/a pull request is pushed/merged to the main branch, the documentation site is automatically built and deployed. 
The documentation site should shortly appear at `OSCA-Kampala-Chapter.github.io/autobot`