### PR TITLE
docs: fix deployment failure due to missing packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.x 
+          python-version: 3.x
       - run: pip install -r docs/requirements.txt
       - run: mkdocs gh-deploy --force

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.x
-      - run: pip install mkdocs-material 
+          python-version: 3.x 
+      - run: pip install -r docs/requirements.txt
       - run: mkdocs gh-deploy --force

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,6 @@
+mkdocs==1.4.2
+mkdocs-autorefs==0.4.1
+mkdocs-material==8.5.10
+mkdocs-material-extensions==1.1.1
+mkdocstrings==0.19.0
+mkdocstrings-python==0.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,12 +9,6 @@ Jinja2==3.1.2
 Markdown==3.3.7
 MarkupSafe==2.1.1
 mergedeep==1.3.4
-mkdocs==1.4.1
-mkdocs-autorefs==0.4.1
-mkdocs-material==8.5.7
-mkdocs-material-extensions==1.1
-mkdocstrings==0.19.0
-mkdocstrings-python==0.7.1
 packaging==21.3
 Pygments==2.13.0
 pymdown-extensions==9.7


### PR DESCRIPTION
This pr closes #125 and creates `docs/requirements.txt` file to hold all packages required for documentation to build.