### PR TITLE
add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+* **Please check if the PR fulfills these requirements**
+- [ ] Tests for the changes have been added (for bug fixes/features)
+- [ ] Docs have been added / updated (for bug fixes / features)
+- [ ] I have included in this PR's description the statement `closes #xx` or `fixes #xx` where #xx is the number of the issue being addressed.
+
+
+* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
+
+
+* **What is the current behavior?** (You can also link to an open issue here)
+
+
+* **What is the new behavior (if this is a feature change)?**
+
+
+* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
+
+
+* **Other information**:
+


### PR DESCRIPTION
This pr closes #106 
Pull request templates allow organizations to have a default text when you create a pull request on GitHub. It is quite useful to make sure to follow a standard process for every pull request and to have a to-do list for the author to check before requesting a review. 